### PR TITLE
Improved handling of invalid or empty list to allow to set defaults

### DIFF
--- a/list-item-card/README.md
+++ b/list-item-card/README.md
@@ -4,7 +4,8 @@
 
 ## Purpose
 
-This is a pretty niche use case. This card takes sensor attributes that are lists of strings and displays them as a card. Each item in the list it displayed on a line with an optional icon as a bullet point.
+This card takes sensor attributes that are lists of strings and displays them as a card. Each item in the list it displayed on a line with an optional icon as a bullet point.
+By default an error message is visualized in case the sensor returns and empty or invalid list. 
 
 ## Installation
 
@@ -39,3 +40,6 @@ _(String) (Optional)_ The icon to prefix each list item. The area will be empty 
 
 ### max_length
 _(Int) (Optional)_ The maximum number of items that will be read from the list. Defaults to 4.
+
+### emptyValue
+_(List) (Optional)_ A list of strings to visualize if the sensor attribute is empty or an invalid list.  To visualize nothing pass an empty list.  

--- a/list-item-card/list-item-card.js
+++ b/list-item-card/list-item-card.js
@@ -37,13 +37,9 @@ class ListItem extends HTMLElement {
         }
 
         let listData = hass.states[this.config.entity].attributes[this.config.attribute];
-        // if the list isn't a list say so
+        // if the list isn't a list, display default empty value
         if (!Array.isArray(listData)) {
-            listData = [
-                `The attribute '${this.config.attribute}'`,
-                ` of entity '${this.config.entity}'`,
-                ` is not a list.`
-            ];
+               listData = this.config.emptyValue; 
         }
 
         // the number of items to display is the small of this.config.max_length or listData.length
@@ -98,6 +94,17 @@ class ListItem extends HTMLElement {
             config['list_icon'] = `icon='${config.icon}'`
             delete config.icon;
         }
+
+ 	/**
+         * Values to visualize if list is empty. 
+         */
+         if (!config.emptyValue || !Array.isArray(config.emptyValue) ) {
+            config.emptyValue =  [
+                `The attribute '${config.attribute}'`,
+                ` of entity '${config.entity}'`,
+                ` is not a list.`
+            ];
+         }
 
         this.config = config;
     }


### PR DESCRIPTION
This is not an niche use case anymore. 
Minecraft server integration returns list of online players exactly in this format and I used your card to display them properly.
With this change the card will work also when there are no players connected.
Thanks!